### PR TITLE
Add dataset collection script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ __pycache__/
 
 # VSCode
 .vscode/
+tomcat/
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Locus Reproduction
+
+This project aims to reproduce the evaluation of **Locus: Locating Bugs from Software Changes** on the Apache Tomcat repository. The included data is intentionally small and only contains a handful of bug reports and commits. To obtain results comparable to the paper, you need to build a dataset from the full Tomcat history and corresponding Bugzilla reports.
+
+## Preparing the Dataset
+
+1. Clone the full Tomcat repository:
+   ```bash
+   git clone https://github.com/apache/tomcat.git tomcat
+   ```
+
+2. Extract commit information (message, diffs) from the repository:
+   ```bash
+   python src/extract_commits.py tomcat data/commits.json --branch main
+   ```
+   Remove `--max-count` to process the entire history or set a limit if needed.
+
+3. Generate bug reports linked to commits:
+   ```bash
+   python tools/collect_dataset.py
+   ```
+   The script scans commit messages for patterns like `Bug 12345` and fetches the corresponding report from Bugzilla. The resulting file `data/bug_reports.json` will contain the mapping used for evaluation.
+
+Once the dataset is generated, rebuild the TF-IDF matrix and run evaluation:
+
+```bash
+python src/build_corpus.py
+python src/evaluate_ranking.py
+```
+
+Using the complete dataset and richer features should yield results closer to those reported in the Locus paper.

--- a/src/extract_commits.py
+++ b/src/extract_commits.py
@@ -1,52 +1,52 @@
-# src/extract_commits.py
-
 import os
-from git import Repo
 import json
-from tqdm import tqdm
 import re
-matches = re.findall(r'bug[\s#]?(\d{3,})', commit_message.lower())
+from argparse import ArgumentParser
+from git import Repo
+from tqdm import tqdm
 
-def extract_commits(repo_path, max_count=1000):
+
+def extract_commits(repo_path: str, branch: str = "main", max_count=None):
     repo = Repo(repo_path)
     commits_data = []
-
-    for commit in tqdm(list(repo.iter_commits('main', max_count=max_count))):
+    iterator = repo.iter_commits(branch, max_count=max_count)
+    for commit in tqdm(list(iterator)):
         if not commit.parents:
-            continue  # skip initial commit
-        
-        diff_data = []
+            continue
         diffs = commit.diff(commit.parents[0], create_patch=True)
+        diff_data = []
         for diff in diffs:
             if diff.new_file or diff.deleted_file:
-                continue  # skip added/deleted files
-            try:
-                patch = diff.diff.decode('utf-8', errors='ignore')
-                diff_data.append({
-                    'file': diff.b_path,
-                    'patch': patch
-                })
-            except Exception as e:
                 continue
-        
+            try:
+                patch = diff.diff.decode("utf-8", errors="ignore")
+                diff_data.append({"file": diff.b_path, "patch": patch})
+            except Exception:
+                continue
         commits_data.append({
-            'hash': commit.hexsha,
-            'message': commit.message.strip(),
-            'author': commit.author.name,
-            'date': commit.committed_datetime.isoformat(),
-            'diffs': diff_data
+            "hash": commit.hexsha,
+            "message": commit.message.strip(),
+            "author": commit.author.name,
+            "date": commit.committed_datetime.isoformat(),
+            "diffs": diff_data,
         })
-
     return commits_data
 
-if __name__ == "__main__":
-    REPO_PATH = "../tomcat"  # あなたの環境に合わせて変更
-    OUTPUT_FILE = "data/commits.json"
 
-    os.makedirs("data", exist_ok=True)
-    commits = extract_commits(REPO_PATH, max_count=1000)
-    
-    with open(OUTPUT_FILE, 'w', encoding='utf-8') as f:
+def main():
+    ap = ArgumentParser(description="Extract commit data from a git repository")
+    ap.add_argument("repo", help="Path to git repository")
+    ap.add_argument("output", help="Path to output JSON file")
+    ap.add_argument("--branch", default="main", help="Branch to scan")
+    ap.add_argument("--max-count", type=int, default=None, help="Limit number of commits")
+    args = ap.parse_args()
+
+    os.makedirs(os.path.dirname(args.output), exist_ok=True)
+    commits = extract_commits(args.repo, branch=args.branch, max_count=args.max_count)
+    with open(args.output, "w", encoding="utf-8") as f:
         json.dump(commits, f, ensure_ascii=False, indent=2)
+    print(f"Saved {len(commits)} commits to {args.output}")
 
-    print(f"Saved {len(commits)} commits to {OUTPUT_FILE}")
+
+if __name__ == "__main__":
+    main()

--- a/tools/collect_dataset.py
+++ b/tools/collect_dataset.py
@@ -1,0 +1,60 @@
+import json
+import os
+import re
+from typing import Dict, List
+
+import git
+import requests
+from bs4 import BeautifulSoup
+from tqdm import tqdm
+
+
+def fetch_bug_report(bug_id: str) -> Dict:
+    """Fetch summary and description for a Bugzilla bug."""
+    url = f"https://bz.apache.org/bugzilla/show_bug.cgi?id={bug_id}"
+    res = requests.get(url, timeout=30)
+    res.raise_for_status()
+    soup = BeautifulSoup(res.text, "html.parser")
+    summary = soup.find("span", id="short_desc_nonedit_display")
+    description = soup.find("pre", class_="bz_comment_text")
+    return {
+        "id": f"BUG-{bug_id}",
+        "summary": summary.text.strip() if summary else "",
+        "description": description.text.strip() if description else "",
+    }
+
+
+def scan_repository(repo_path: str) -> Dict[str, List[str]]:
+    """Scan git history and return mapping bug_id -> list of commits."""
+    repo = git.Repo(repo_path)
+    bug_map: Dict[str, List[str]] = {}
+    pattern = re.compile(r"bug\s*(\d{3,6})", re.IGNORECASE)
+    for commit in tqdm(repo.iter_commits("main")):
+        matches = pattern.findall(commit.message)
+        for bid in matches:
+            bug_map.setdefault(bid, []).append(commit.hexsha)
+    return bug_map
+
+
+def main():
+    repo_path = os.environ.get("TOMCAT_REPO", "tomcat")
+    bug_map = scan_repository(repo_path)
+
+    reports = []
+    for bug_id, commits in tqdm(bug_map.items()):
+        try:
+            br = fetch_bug_report(bug_id)
+            br["fixes"] = [c[:7] for c in commits]
+            reports.append(br)
+        except Exception as e:
+            print(f"Failed to fetch BUG-{bug_id}: {e}")
+
+    os.makedirs("data", exist_ok=True)
+    with open("data/bug_reports.json", "w") as f:
+        json.dump(reports, f, indent=2)
+
+    print(f"Saved {len(reports)} bug reports to data/bug_reports.json")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add instructions on fetching the full Tomcat dataset
- support full history extraction in `extract_commits.py`
- provide a new script `collect_dataset.py` that pulls Bugzilla reports from commit messages
- ignore the `tomcat/` checkout in git

## Testing
- `python -m py_compile tools/collect_dataset.py src/extract_commits.py`


------
https://chatgpt.com/codex/tasks/task_e_6851677b1550832190f8b75ec0f4a632