### PR TITLE
Improve Locus evaluation

### DIFF
--- a/src/build_corpus.py
+++ b/src/build_corpus.py
@@ -29,6 +29,7 @@ def load_commit_corpus(filepath):
 
     documents = []
     ids = []
+    dates = []
 
     for commit in commits:
         # message + hunk patch 全体を1つの document にする
@@ -42,8 +43,9 @@ def load_commit_corpus(filepath):
 
         documents.append(full_text)
         ids.append(commit['hash'])
+        dates.append(commit.get('date'))
 
-    return ids, documents
+    return ids, documents, dates
 
 def build_tfidf_matrix(documents):
     vectorizer = TfidfVectorizer(stop_words='english', max_features=10000)
@@ -55,7 +57,7 @@ if __name__ == "__main__":
     output_matrix = "data/tfidf.npz"
     output_ids = "data/commit_ids.json"
 
-    ids, docs = load_commit_corpus(input_file)
+    ids, docs, dates = load_commit_corpus(input_file)
     tfidf_matrix, vectorizer = build_tfidf_matrix(docs)
 
     # 保存
@@ -64,5 +66,8 @@ if __name__ == "__main__":
 
     with open(output_ids, 'w') as f:
         json.dump(ids, f)
+
+    with open("data/commit_dates.json", 'w') as f:
+        json.dump(dates, f)
 
     print(f"TF-IDF matrix saved to {output_matrix}")

--- a/src/compute_similarity.py
+++ b/src/compute_similarity.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
 
     # vectorizer再構築
     from src.build_corpus import load_commit_corpus, build_tfidf_matrix
-    _, docs = load_commit_corpus("data/commits.json")
+    _, docs, _ = load_commit_corpus("data/commits.json")
     _, vectorizer = build_tfidf_matrix(docs)
 
     for bug_id, bug_text in bug_reports:

--- a/tools/collect_dataset.py
+++ b/tools/collect_dataset.py
@@ -17,10 +17,19 @@ def fetch_bug_report(bug_id: str) -> Dict:
     soup = BeautifulSoup(res.text, "html.parser")
     summary = soup.find("span", id="short_desc_nonedit_display")
     description = soup.find("pre", class_="bz_comment_text")
+
+    created = None
+    th = soup.find("th", string=re.compile("Reported"))
+    if th:
+        td = th.find_next("td")
+        if td:
+            created = td.text.strip().split(" by ")[0]
+
     return {
         "id": f"BUG-{bug_id}",
         "summary": summary.text.strip() if summary else "",
         "description": description.text.strip() if description else "",
+        "created": created,
     }
 
 


### PR DESCRIPTION
## Summary
- capture bug report creation time in dataset collection
- preserve commit dates when building the corpus
- update similarity and evaluation logic for time filtering
- compute metrics on changed files instead of just commit IDs

## Testing
- `python -m compileall -q src tools`
- `python src/evaluate_ranking.py | head`

------
https://chatgpt.com/codex/tasks/task_e_6851d190420c832188eb1129433ad944